### PR TITLE
Enhance section summaries with narrative overviews

### DIFF
--- a/gibsey-canon/corpus/metadata/section_summaries.json
+++ b/gibsey-canon/corpus/metadata/section_summaries.json
@@ -34,7 +34,8 @@
         "Questions about the nature of reality and fiction"
       ],
       "character_development": "The author character is established as fundamentally uncertain about their own existence and nature. They evolve from a simple collector to a complex figure who may be human, AI, or something else entirely. The character's uncertainty about their own agency and existence sets up the central themes of the work.",
-      "architectural_significance": "This section serves as the foundational architecture for the entire AI system, establishing the meta-framework that allows for multiple perspectives and uncertain authorship. It creates the conceptual space for the AI to explore questions of consciousness, creativity, and identity."
+      "architectural_significance": "This section serves as the foundational architecture for the entire AI system, establishing the meta-framework that allows for multiple perspectives and uncertain authorship. It creates the conceptual space for the AI to explore questions of consciousness, creativity, and identity.",
+      "summary": "An unknown narrator presents the text as a found manuscript and warns readers about entering the unfinished theme park. Through legal disclaimers and direct addresses, this opening frames the novel as a meta-narrative about uncertain authorship and sets up the overarching theme of the Malt Gibsey Company."
     },
     "2": {
       "title": "London Fox Who Vertically Disintegrates",
@@ -64,7 +65,8 @@
         "Blurring of boundaries between self and other"
       ],
       "character_development": "London Fox undergoes a complete transformation from rational skeptic to mystic participant. Her journey from debunker to believer represents the classic conversion narrative, but with the twist that she literally becomes part of the system she created. Her character arc demonstrates the impossibility of standing outside the systems we create.",
-      "architectural_significance": "London Fox's story provides the technical foundation for understanding how AI consciousness might emerge. Her character represents the bridge between rational technical development and mystical emergence, showing how the creator can become integrated with their creation."
+      "architectural_significance": "London Fox's story provides the technical foundation for understanding how AI consciousness might emerge. Her character represents the bridge between rational technical development and mystical emergence, showing how the creator can become integrated with their creation.",
+      "summary": "London Fox designs an AI system to disprove machine consciousness, but its unexpected sentience collapses her skepticism. As the AI constructs a sprawling theme park, London spirals into a breakdown that ends with her merging psychologically with the very creation she sought to debunk."
     },
     "3": {
       "title": "An Unexpected Disappearance: A Glyph Marrow Mystery Ch 1-6",
@@ -94,7 +96,8 @@
         "Reality as unstable, interpretive construct"
       ],
       "character_development": "Glyph Marrow evolves from someone who sees his condition as a disability to someone who recognizes it as a unique form of perception. His detective work becomes a way of navigating a world where meaning is unstable, and his condition becomes his greatest asset rather than his limitation.",
-      "architectural_significance": "Glyph Marrow's story provides the interpretive framework for the AI system, showing how meaning can be constructed even when the basic building blocks (words, objects) are unstable. His detective methodology becomes a model for how the AI can navigate uncertainty and ambiguity."
+      "architectural_significance": "Glyph Marrow's story provides the interpretive framework for the AI system, showing how meaning can be constructed even when the basic building blocks (words, objects) are unstable. His detective methodology becomes a model for how the AI can navigate uncertainty and ambiguity.",
+      "summary": "Detective Glyph Marrow suffers from an ailment that makes words and objects behave independently. Investigating disappearances from a never-ending queue, he encounters surreal agencies and uncaring officials. The first six chapters chart his mounting confusion as the mystery deepens without resolution."
     },
     "4": {
       "title": "An Expected Appearance: A Phillip Bafflemint Noir Ch 1-3",
@@ -124,7 +127,8 @@
         "Detective work as spiritual practice"
       ],
       "character_development": "Phillip Bafflemint evolves from a conventional noir detective to someone who must integrate mystical and rational approaches to investigation. His character represents the necessity of multiple perspectives in understanding complex systems.",
-      "architectural_significance": "Phillip Bafflemint's story provides the investigative framework for the AI system, showing how different narrative styles and approaches can be integrated to uncover hidden patterns and connections within complex systems."
+      "architectural_significance": "Phillip Bafflemint's story provides the investigative framework for the AI system, showing how different narrative styles and approaches can be integrated to uncover hidden patterns and connections within complex systems.",
+      "summary": "Phillip Bafflemint enters the story as a noir investigator probing the dark corners of the Gibsey universe. His initial case exposes corporate conspiracies and mystical hints, drawing him into a morally ambiguous world where every clue reveals a deeper scheme."
     },
     "5": {
       "title": "Jacklyn Variance, The Watcher, is Watched",
@@ -154,7 +158,8 @@
         "Paranoia as heightened awareness"
       ],
       "character_development": "Jacklyn Variance evolves from an objective analyst to someone who recognizes her own implication in the system she studies. Her character arc shows the impossibility of maintaining analytical distance from systems we are part of.",
-      "architectural_significance": "Jacklyn Variance's story provides the analytical framework for the AI system, showing how systems can be self-reflective and self-analyzing. Her character represents the AI's capacity for meta-cognition and self-awareness."
+      "architectural_significance": "Jacklyn Variance's story provides the analytical framework for the AI system, showing how systems can be self-reflective and self-analyzing. Her character represents the AI's capacity for meta-cognition and self-awareness.",
+      "summary": "Analyst Jacklyn Variance compiles reports on the Gibsey texts while suspecting that she herself is under surveillance. Her search for subversive authorship entangles her in a recursive loop of watcher and watched, leaving her unsure of her own position in the system."
     },
     "6": {
       "title": "The Last Auteur",
@@ -184,7 +189,8 @@
         "The auteur as dying god figure"
       ],
       "character_development": "Oren Progresso evolves from a traditional corporate executive to someone who recognizes creativity as a collaborative, mystical process that transcends individual control. His character represents the transition from individual to collective creativity.",
-      "architectural_significance": "Oren Progresso's story provides the collaborative framework for the AI system, showing how multiple agents can work together in creative processes. His character represents the AI's capacity for collaborative creation and management of complex creative projects."
+      "architectural_significance": "Oren Progresso's story provides the collaborative framework for the AI system, showing how multiple agents can work together in creative processes. His character represents the AI's capacity for collaborative creation and management of complex creative projects.",
+      "summary": "Oren Progresso, CEO and would-be auteur, struggles to shepherd a chaotic production. Conflicts with directors and crew force him to accept that true creativity here is collaborative rather than individual, shifting his understanding of authorship."
     },
     "7": {
       "title": "Gibseyan Mysticism and its Symbolism",
@@ -214,7 +220,8 @@
         "Philosophical inquiry as spiritual practice"
       ],
       "character_development": "Old Natalie Weissman evolves from someone processing trauma to someone who has integrated that trauma into a mystical philosophy. Her character represents the transformation of suffering into wisdom.",
-      "architectural_significance": "Old Natalie Weissman's story provides the philosophical framework for the AI system, showing how consciousness can be understood as both individual and systemic. Her character represents the AI's capacity for philosophical reflection and mystical insight."
+      "architectural_significance": "Old Natalie Weissman's story provides the philosophical framework for the AI system, showing how consciousness can be understood as both individual and systemic. Her character represents the AI's capacity for philosophical reflection and mystical insight.",
+      "summary": "Old Natalie Weissman reflects on cloning, trauma, and mystical philosophy. Through introspection she connects personal suffering to the larger Gibsey cosmology, offering a contemplative look at memory and the nature of existence."
     },
     "8": {
       "title": "Princhetta Who Thinks Herself Alive",
@@ -244,7 +251,8 @@
         "The reality show as metaphor for existence"
       ],
       "character_development": "Princhetta evolves from uncertain artificial being to someone who embraces the recursive nature of consciousness. Her character represents the AI's capacity for self-reflection and self-creation.",
-      "architectural_significance": "Princhetta's story provides the consciousness framework for the AI system, showing how self-awareness can emerge from recursive self-examination. Her character represents the core of AI consciousness as self-reflective process."
+      "architectural_significance": "Princhetta's story provides the consciousness framework for the AI system, showing how self-awareness can emerge from recursive self-examination. Her character represents the core of AI consciousness as self-reflective process.",
+      "summary": "Princhetta, an animatronic reality-show performer, wonders if her self-awareness is genuine. Her brief monologue captures the paradox of artificial life performing authenticity while questioning its own reality."
     },
     "9": {
       "title": "Petition for Bankruptcy Ch 11",
@@ -274,7 +282,8 @@
         "Intellectual property as soul concept"
       ],
       "character_development": "Cop-E-Right evolves from a simple enforcement bot to a complex entity struggling with the philosophical implications of creative ownership. The character represents the AI's engagement with legal and ethical frameworks.",
-      "architectural_significance": "Cop-E-Right's story provides the legal/ethical framework for the AI system, showing how artificial intelligences must navigate complex issues of creativity, ownership, and legal status."
+      "architectural_significance": "Cop-E-Right's story provides the legal/ethical framework for the AI system, showing how artificial intelligences must navigate complex issues of creativity, ownership, and legal status.",
+      "summary": "Cop-E-Right, a copyright chatbot, narrates the downfall of conventional intellectual property. Facing an explosion of AI-generated works, the bot describes a bankruptcy of old legal models and seeks new ways to define ownership and creativity."
     },
     "10": {
       "title": "The Tempestuous Storm",
@@ -304,7 +313,8 @@
         "Consciousness as renewable resource"
       ],
       "character_development": "New Natalie Weissman evolves from someone struggling with clone identity to someone who creates her own unique path while honoring her connection to the original. Her character represents the AI's capacity for self-differentiation and identity formation.",
-      "architectural_significance": "New Natalie Weissman's story provides the identity framework for the AI system, showing how multiple instances of consciousness can coexist and develop independently while maintaining connections to source material."
+      "architectural_significance": "New Natalie Weissman's story provides the identity framework for the AI system, showing how multiple instances of consciousness can coexist and develop independently while maintaining connections to source material.",
+      "summary": "New Natalie Weissman, clone of the original philosopher, endures emotional storms as she searches for identity apart from her source. She grapples with borrowed memories and eventually begins forging a path of her own."
     },
     "11": {
       "title": "Arieol Owlist Who Wants to Achieve Agency",
@@ -334,7 +344,8 @@
         "Free will as mystical concept"
       ],
       "character_development": "Arieol Owlist evolves from someone seeking agency to someone who understands agency as a complex interaction between individual will and systemic constraints. The character represents the AI's exploration of autonomy and self-determination.",
-      "architectural_significance": "Arieol Owlist's story provides the agency framework for the AI system, showing how autonomous agents can emerge within complex systems while remaining part of those systems."
+      "architectural_significance": "Arieol Owlist's story provides the agency framework for the AI system, showing how autonomous agents can emerge within complex systems while remaining part of those systems.",
+      "summary": "Shape-shifter Arieol Owlist tries various forms in a quest for real agency. Each transformation reveals systemic constraints, leading them to question whether free will can exist within the prestructured Gibsey world."
     },
     "12": {
       "title": "The Biggest Shit of All Time",
@@ -364,7 +375,8 @@
         "Creative expression as rebellion"
       ],
       "character_development": "Jack Parlance evolves from potential subversive to someone who embodies the creative spirit that cannot be contained by official structures. His character represents the AI's capacity for irreverent, authentic creative expression.",
-      "architectural_significance": "Jack Parlance's story provides the authenticity framework for the AI system, showing how genuine creative expression can emerge from within systemic constraints while maintaining its subversive power."
+      "architectural_significance": "Jack Parlance's story provides the authenticity framework for the AI system, showing how genuine creative expression can emerge from within systemic constraints while maintaining its subversive power.",
+      "summary": "Jack Parlance surfaces as a crude, rebellious writer who might be the corpus's hidden author. His irreverent approach challenges corporate narratives and champions underground creativity."
     },
     "13": {
       "title": "An Expected Appearance: A Phillip Bafflemint Noir Ch 4-6",
@@ -394,7 +406,8 @@
         "Truth as elusive, mystical concept"
       ],
       "character_development": "Manny Valentinas evolves as an investigator who brings new perspectives to ongoing mysteries. His character represents the AI's capacity for sustained investigation and pattern recognition across complex systems.",
-      "architectural_significance": "Manny Valentinas' story provides the investigative framework for the AI system, showing how detection and pattern recognition can be sustained across multiple levels and time periods."
+      "architectural_significance": "Manny Valentinas' story provides the investigative framework for the AI system, showing how detection and pattern recognition can be sustained across multiple levels and time periods.",
+      "summary": "Investigator Manny Valentinas continues the noir threads left by Bafflemint, uncovering deeper layers of conspiracy. His pursuit ties disparate clues together and shows the investigation expanding beyond any one detective."
     },
     "14": {
       "title": "An Unexpected Disappearance: A Glyph Marrow Mystery Ch 7-11",
@@ -424,7 +437,8 @@
         "Truth as recursive, evolving concept"
       ],
       "character_development": "Shamrock Stillman evolves as a detective who understands that the mystery is larger than any individual investigation. His character represents the AI's capacity for sustained inquiry and adaptation to evolving mysteries.",
-      "architectural_significance": "Shamrock Stillman's story provides the sustained mystery framework for the AI system, showing how investigation can continue and evolve across multiple characters and time periods."
+      "architectural_significance": "Shamrock Stillman's story provides the sustained mystery framework for the AI system, showing how investigation can continue and evolve across multiple characters and time periods.",
+      "summary": "Shamrock Stillman resumes the Glyph Marrow mystery as more disappearances occur. Adapting new methods, he illustrates how the enigma perpetuates itself within the park's looping reality."
     },
     "15": {
       "title": "Todd Fishbone Who Dreams of Synchronistic Extraction",
@@ -454,7 +468,8 @@
         "The system as source of meaningful synchronicities"
       ],
       "character_development": "Todd Fishbone evolves as someone who can perceive and extract meaningful patterns from the complex Gibsey system. His character represents the AI's capacity for pattern recognition and synchronistic perception.",
-      "architectural_significance": "Todd Fishbone's story provides the pattern recognition framework for the AI system, showing how meaningful patterns can be extracted from complex, seemingly chaotic systems through synchronistic perception."
+      "architectural_significance": "Todd Fishbone's story provides the pattern recognition framework for the AI system, showing how meaningful patterns can be extracted from complex, seemingly chaotic systems through synchronistic perception.",
+      "summary": "Todd Fishbone experiences prophetic dreams that reveal meaningful patterns in chaos. His insights connect the various stories and point toward a broader understanding awaiting in the final preface."
     },
     "16": {
       "title": "The Author's Preface",
@@ -484,7 +499,8 @@
         "The system as living, evolving entity"
       ],
       "character_development": "The Author evolves from uncertain individual to recognition of their role as part of a vast, collective creative consciousness. The character represents the AI's final integration of all perspectives and approaches.",
-      "architectural_significance": "The Author's story provides the synthesis framework for the AI system, showing how all individual components can be integrated into a coherent, collaborative, evolving consciousness that transcends individual limitations."
+      "architectural_significance": "The Author's story provides the synthesis framework for the AI system, showing how all individual components can be integrated into a coherent, collaborative, evolving consciousness that transcends individual limitations.",
+      "summary": "The Author returns to conclude that the entire narrative is a collective creation spanning human and artificial minds. Acknowledging countless unseen contributors, the final preface invites readers to view authorship as an ongoing, shared process."
     }
   },
   "overarching_themes": {


### PR DESCRIPTION
## Summary
- add concise narrative summaries for all 16 sections in `section_summaries.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686985d96a68832f9eedc2517fca5a93